### PR TITLE
貸出一覧、登録画面修正

### DIFF
--- a/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
+++ b/src/main/java/jp/co/metateam/library/controller/RentalManageController.java
@@ -1,14 +1,46 @@
 package jp.co.metateam.library.controller;
 
+import java.time.LocalDate;
+import java.util.List;
+
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import jp.co.metateam.library.service.AccountService;
+import jp.co.metateam.library.service.BookMstService;
+
 import jp.co.metateam.library.service.RentalManageService;
 import jp.co.metateam.library.service.StockService;
+import jakarta.validation.Valid;
+
+import jp.co.metateam.library.model.BookMst;
+import jp.co.metateam.library.model.Stock;
+import jp.co.metateam.library.model.Account;
+
+import jp.co.metateam.library.model.RentalManage;
+import jp.co.metateam.library.model.BookMstDto;
+
+import jp.co.metateam.library.model.StockDto;
+import jp.co.metateam.library.model.RentalManageDto;
+
+import jp.co.metateam.library.values.StockStatus;
+import jp.co.metateam.library.values.RentalStatus;
+
+
 import lombok.extern.log4j.Log4j2;
+
+/**
+
+
 
 /**
  * 貸出管理関連クラスß
@@ -28,8 +60,9 @@ public class RentalManageController {
         StockService stockService
     ) {
         this.accountService = accountService;
-        this.rentalManageService = rentalManageService;
         this.stockService = stockService;
+        this.rentalManageService = rentalManageService;
+
     }
 
     /**
@@ -40,11 +73,55 @@ public class RentalManageController {
     @GetMapping("/rental/index")
     public String index(Model model) {
         // 貸出管理テーブルから全件取得
+        List<RentalManage> rentalManageList = this.rentalManageService.findAll();
+        
+        model.addAttribute("rentalManageList", rentalManageList);
 
+        return "rental/index";
         // 貸出一覧画面に渡すデータをmodelに追加
+       
+    }
+     
+      @GetMapping("/rental/add")
+        public String add(Model model) {
+            List<Stock> stockList = this.stockService.findAll();
+            List<Account> accounts = this.accountService.findAll();
+           
 
-        // 貸出一覧画面に遷移
-        return "";
+    
+            model.addAttribute("accounts", accounts);
+            model.addAttribute("stockList", stockList);
+            model.addAttribute("rentalStatus", RentalStatus.values());
+    
+            if (!model.containsAttribute("rentalManageDto")) {
+                model.addAttribute("rentalManageDto", new RentalManageDto());
+            }
+    
+            return "rental/add";
+        }
+         
+        @PostMapping("/rental/add")
+        public String save(@Valid @ModelAttribute RentalManageDto rentalManageDto, BindingResult result, RedirectAttributes ra) {
+            try {
+                if (result.hasErrors()) {
+                    throw new Exception("Validation error.");
+                }
+                // 登録処理
+                this.rentalManageService.save(rentalManageDto);
+    
+                return "redirect:/rental/index";
+            
+            } catch (Exception e) {
+                log.error(e.getMessage());
+    
+                ra.addFlashAttribute("rentalManageDto", rentalManageDto);
+                ra.addFlashAttribute("org.springframework.validation.BindingResult.rentalManageDto", result);
+    
+                return "redirect:/rental/add";
+            }
+
+        }      
+       
+        
     }
 
-}


### PR DESCRIPTION

・概要 

貸出登録、一覧画面を追加
RentalManageController メソッドで貸出登録の処理をするよう修正
　　　　　　　　　　　　　　　　貸出一覧の表示をするよう修正

・テスト証跡 

＊「社員番号、在庫管理番号、貸出ステータス」のプルダウンがそれぞれ表示されているか
＊必須項目を抜かした場合、エラーが表示されるか
＊貸出予定日と返却予定日がそれぞれ正しい時系列で登録されない場合エラー表示がされるか




